### PR TITLE
stripes / multiple / animation arguments

### DIFF
--- a/R/shiny-tree.R
+++ b/R/shiny-tree.R
@@ -21,12 +21,17 @@
 #' @param unique If \code{TRUE}, will ensure that no node name exists more
 #' than once.
 #' @param wholerow If \code{TRUE}, will highlight the whole selected row.
+#' @param stripes If \code{TRUE}, the tree background is striped.
+#' @param multiple If \code{TRUE}, multiple nodes can be selected.
+#' @param animation The open / close animation duration in milliseconds.
+#' Det this to \code{FALSE} to disable the animation (default is 200).
 #' @seealso \code{\link{renderTree}}
 #' @export
 shinyTree <- function(outputId, checkbox=FALSE, search=FALSE, 
                       searchtime = 250, dragAndDrop=FALSE, types=NULL, 
                       theme="default", themeIcons=TRUE, themeDots=TRUE,
-                      sort=FALSE, unique=FALSE, wholerow=FALSE){
+                      sort=FALSE, unique=FALSE, wholerow=FALSE,
+                      stripes=FALSE, multiple=TRUE, animation=200){
   searchEl <- shiny::div("")
   if (search == TRUE){
     search <- paste0(outputId, "-search-input")
@@ -45,7 +50,9 @@ shinyTree <- function(outputId, checkbox=FALSE, search=FALSE,
                                type = 'text/css',
                                href = paste('shinyTree/jsTree-3.3.7/themes/',theme,'/style.min.css',sep=""))
   
-  
+  if(!animation){
+    animation = 'false'
+  }
   if(!is.null(types)){
     types <- paste("sttypes =",types)
   }
@@ -71,6 +78,9 @@ shinyTree <- function(outputId, checkbox=FALSE, search=FALSE,
         `data-st-theme`=theme,
         `data-st-theme-icons`=themeIcons,
         `data-st-theme-dots`=themeDots,
+        `data-st-theme-stripes`=stripes,
+        `data-st-multiple`=multiple,
+        `data-st-animation`=animation,
         `data-st-sort`=sort,
         `data-st-unique`=unique,
         `data-st-wholerow`=wholerow

--- a/inst/examples/01-simple/server.R
+++ b/inst/examples/01-simple/server.R
@@ -10,6 +10,10 @@ shinyServer(function(input, output, session) {
       root2 = list(
         SubListA = list(leaf1 = "", leaf2 = "", leaf3=""),
         SubListB = list(leafA = "", leafB = "")
+      ),
+      root3 = list(
+        SubListA = list(leaf1 = "", leaf2 = "", leaf3=""),
+        SubListB = list(leafA = "", leafB = "")
       )
     )
   })

--- a/inst/examples/01-simple/ui.R
+++ b/inst/examples/01-simple/ui.R
@@ -14,6 +14,6 @@ shinyUI(
     ),
     mainPanel(
       # Show a simple table.
-      shinyTree("tree")
+      shinyTree("tree", stripes = TRUE, multiple = FALSE, animation = FALSE)
     )
   ))

--- a/inst/www/shinyTree.js
+++ b/inst/www/shinyTree.js
@@ -37,12 +37,18 @@ var shinyTree = function(){
         plugins.push('wholerow');
       }
       
-      var tree = $(el).jstree({'core': {
-          "check_callback" : ($elem.data('st-dnd') === 'TRUE'), 
-          'themes': {'name': $elem.data('st-theme'), 
-          'responsive': true, 
-          'icons': ($elem.data('st-theme-icons') === 'TRUE'),
-          'dots': ($elem.data('st-theme-dots') === 'TRUE') }
+      var tree = $(el).jstree({
+        'core': {
+          "check_callback" : ($elem.data('st-dnd') === 'TRUE'),
+          'multiple': ($elem.data('st-multiple') === 'TRUE'),
+          'animation': $elem.data('st-animation'),
+          'themes': {
+            'name': $elem.data('st-theme'), 
+            'responsive': true, 
+            'stripes': ($elem.data('st-theme-stripes') === 'TRUE'),
+            'icons': ($elem.data('st-theme-icons') === 'TRUE'),
+            'dots': ($elem.data('st-theme-dots') === 'TRUE') 
+          }
         },
         "types" : sttypes,
         plugins: plugins});

--- a/man/shinyTree.Rd
+++ b/man/shinyTree.Rd
@@ -7,7 +7,8 @@
 shinyTree(outputId, checkbox = FALSE, search = FALSE,
   searchtime = 250, dragAndDrop = FALSE, types = NULL,
   theme = "default", themeIcons = TRUE, themeDots = TRUE,
-  sort = FALSE, unique = FALSE, wholerow = FALSE)
+  sort = FALSE, unique = FALSE, wholerow = FALSE, stripes = FALSE,
+  multiple = TRUE, animation = 200)
 }
 \arguments{
 \item{outputId}{The ID associated with this element}
@@ -40,6 +41,13 @@ order.}
 than once.}
 
 \item{wholerow}{If \code{TRUE}, will highlight the whole selected row.}
+
+\item{stripes}{If \code{TRUE}, the tree background is striped.}
+
+\item{multiple}{If \code{TRUE}, multiple nodes can be selected.}
+
+\item{animation}{The open / close animation duration in milliseconds.
+Det this to \code{FALSE} to disable the animation (default is 200).}
 }
 \description{
 This creates a spot in your Shiny UI for a shinyTree which can then be filled


### PR DESCRIPTION
Gives options to:
- set stripes as background
- change `multiple` argument to FALSE if multiselection is not required
- change the `animation` duration. Can also be disabled with 0 or FALSE.