### PR TITLE
fix types in modules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ Authors@R: c(
   person("Mike", "Schaffer", role=c("cre"), email="mschaff@gmail.com"),
   person("Timm", "Danker", role=c("ctb"), email="tidafr@carina.uberspace.de"),
   person("Michael", "Bell", role=c("ctb"), email="bell_michael_a@lilly.com"),
-  person("Sebastian", "Gatscha", role=c("ctb"), email="kona1@gmx.at"))
+  person("Sebastian", "Gatscha", role=c("ctb"), email="kona1@gmx.at"),
+  person("Thorn", "Thaler", role = c("ctb"), email = "thorn.thaler@thothal.at"))
 Description: Exposes bindings to jsTree -- a JavaScript library
     that supports interactive trees -- to enable a rich, editable trees in
     Shiny.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Authors@R: c(
   person(family="jQuery Foundation, Inc.", role=c("ctb", "cph")),
   person("Mike", "Schaffer", role=c("cre"), email="mschaff@gmail.com"),
   person("Timm", "Danker", role=c("ctb"), email="tidafr@carina.uberspace.de"),
-  person("Michael", "Bell", role=c("ctb"), email="bell_michael_a@lilly.com"))
+  person("Michael", "Bell", role=c("ctb"), email="bell_michael_a@lilly.com"),
+  person("Sebastian", "Gatscha", role=c("ctb"), email="kona1@gmx.at"))
 Description: Exposes bindings to jsTree -- a JavaScript library
     that supports interactive trees -- to enable a rich, editable trees in
     Shiny.

--- a/R/shiny-tree.R
+++ b/R/shiny-tree.R
@@ -24,7 +24,7 @@
 #' @param stripes If \code{TRUE}, the tree background is striped.
 #' @param multiple If \code{TRUE}, multiple nodes can be selected.
 #' @param animation The open / close animation duration in milliseconds.
-#' Det this to \code{FALSE} to disable the animation (default is 200).
+#' Set this to \code{FALSE} to disable the animation (default is 200).
 #' @param contextmenu If \code{TRUE}, will enable a contextmenu to 
 #' create/rename/delete/cut/copy/paste nodes.
 #' @seealso \code{\link{renderTree}}
@@ -64,7 +64,8 @@ shinyTree <- function(outputId, checkbox=FALSE, search=FALSE,
     animation = 'false'
   }
   if(!is.null(types)){
-    types <- paste0(outputId,"_sttypes = ",types)
+    outputnohyp <- gsub("-","_",outputId, fixed=T)
+    types <- paste0(outputnohyp,"_sttypes = ",types)
   }
   shiny::tagList(
     shiny::singleton(shiny::tags$head(

--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ runApp(system.file("examples/17-contextmenu", package="shinyTree"))
 
 Demonstrates how to enable the contextmenu.
 
+#### 18-modules
+
+```
+library(shiny)
+runApp(system.file("examples/18-modules", package="shinyTree"))
+```
+
+Demonstrates how to use shinyTree with shiny modules.
+
+
 Known Bugs
 ----------
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ Demonstrates how to enable the contextmenu.
 
 ```
 library(shiny)
-runApp(system.file("examples/18-modules", package="shinyTree"))
+runApp(system.file("examples/18-modules/app.R", package="shinyTree"))
+runApp(system.file("examples/18-modules/app_types.R", package="shinyTree"))
 ```
 
 Demonstrates how to use shinyTree with shiny modules.

--- a/inst/examples/18-modules/app.R
+++ b/inst/examples/18-modules/app.R
@@ -1,0 +1,45 @@
+library(shiny)
+library(shinyTree)
+
+## Tree Data + Function ############
+elem <- structure("", sttype = "elem", sticon = "fa fa-file")
+my_tree <- list(root1 = structure(list(elem1 = elem, elem2 = elem, elem3 = elem), 
+                                  sttype = "root", sticon = "fa fa-archive"),
+                root2 = structure(list(elem1 = elem, elem2 = elem, elem3 = elem), 
+                                  sttype = "root", sticon = "fa fa-archive"),
+                root3 = structure(list(elem1 = elem, elem2 = elem, elem3 = elem),
+                                  sttype = "root", sticon = "fa fa-archive"))
+
+get_part_tree <- function(scope) {
+  part_tree <- my_tree[-sample(3, 1)]
+  names(part_tree) <- paste(scope, names(part_tree), sep = "_")
+  part_tree
+}
+
+## Module UI + Server Function ############
+tree_module_ui <- function(id) {
+  ns <- NS(id)
+  tagList(
+    actionButton(ns("go"), "Go!"),
+    h4("Tree with Types"),
+    shinyTree(ns("tree_with_type"))
+  )
+}
+tree_module <- function(input, output, session) {
+  output$tree_with_type <- renderTree({
+    input$go
+    get_part_tree("Module w/ Type")
+  })
+}
+
+## UI + Server ############
+ui <- fluidPage(
+  h3("Module"),
+  tree_module_ui("tree_module")
+)
+server <- function(input, output, session) {
+  callModule(tree_module,
+             "tree_module")
+}
+
+shinyApp(ui, server)

--- a/inst/examples/18-modules/app_types.R
+++ b/inst/examples/18-modules/app_types.R
@@ -1,0 +1,54 @@
+library(shiny)
+library(shinyTree)
+
+elem <- structure("", sttype = "elem")
+my_tree <- list(root1 = structure(list(elem1 = elem, elem2 = elem, elem3 = elem), 
+                                  sttype = "root"),
+                root2 = structure(list(elem1 = elem, elem2 = elem, elem3 = elem), 
+                                  sttype = "root"),
+                root3 = structure(list(elem1 = elem, elem2 = elem, elem3 = elem),
+                                  sttype = "root"))
+
+get_part_tree <- function(scope) {
+  part_tree <- my_tree[-sample(3, 1)]
+  names(part_tree) <- paste(scope, names(part_tree), sep = "_")
+  part_tree
+}
+tree_module_ui <- function(id) {
+  ns <- NS(id)
+  tagList(
+    actionButton(ns("go"), "Go!"),
+    h4("Tree with Types"),
+    shinyTree(ns("tree_with_type"),
+              types = "{'root': {'icon': 'fa fa-archive'}, 'elem':{'icon': 'fa fa-file'}}"),
+    h4("Tree without Types"),
+    shinyTree(ns("tree_without_type"))
+  )
+}
+tree_module <- function(input, output, session) {
+  output$tree_without_type <- renderTree({
+    input$go
+    get_part_tree("Module w/o Type")
+  })
+  
+  output$tree_with_type <- renderTree({
+    input$go
+    get_part_tree("Module w/ Type")
+  })
+}
+
+ui <- fluidPage(
+  h3("Module 1"),
+  tree_module_ui("tree_module1"),
+  h3("Module 2"),
+  tree_module_ui("tree_module2")
+)
+
+server <- function(input, output, session) {
+  callModule(tree_module,
+             "tree_module1")
+  callModule(tree_module,
+             "tree_module2")
+}
+
+shinyApp(ui, server)

--- a/inst/www/shinyTree.js
+++ b/inst/www/shinyTree.js
@@ -39,8 +39,9 @@ var shinyTree = function(){
         plugins.push('contextmenu');
       }
       var sttypes = null;
-      if(typeof window[el.id + "_sttypes"] !== 'undefined'){
-        sttypes = window[el.id + "_sttypes"];
+      var elidtypes = el.id.replace("-", '_');
+      if (typeof window[elidtypes + "_sttypes"] !== 'undefined'){
+      	sttypes = window[elidtypes + "_sttypes"];
       }
       var tree = $(el).jstree({
         'core': {

--- a/man/shinyTree.Rd
+++ b/man/shinyTree.Rd
@@ -47,7 +47,7 @@ than once.}
 \item{multiple}{If \code{TRUE}, multiple nodes can be selected.}
 
 \item{animation}{The open / close animation duration in milliseconds.
-Det this to \code{FALSE} to disable the animation (default is 200).}
+Set this to \code{FALSE} to disable the animation (default is 200).}
 
 \item{contextmenu}{If \code{TRUE}, will enable a contextmenu to 
 create/rename/delete/cut/copy/paste nodes.}


### PR DESCRIPTION
This should close #81.

There are 2 examples of `shinyTree` in modules, 1 that shows how to pass icons directly to the tree list (app.R) and the other uses the types argument to display icons (app_types.R).