### PR TITLE
Allow usage of shinyTree in modules, closes #81

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Authors@R: c(
   person(family="jQuery Foundation, Inc.", role=c("ctb", "cph")),
   person("Mike", "Schaffer", role=c("cre"), email="mschaff@gmail.com"),
   person("Timm", "Danker", role=c("ctb"), email="tidafr@carina.uberspace.de"),
-  person("Michael", "Bell", role=c("ctb"), email="bell_michael_a@lilly.com"))
+  person("Michael", "Bell", role=c("ctb"), email="bell_michael_a@lilly.com"),
+  person("Thorn", "Thaler", role = c("ctb"), email = "thorn.thaler@thothal.at"))
 Description: Exposes bindings to jsTree -- a JavaScript library
     that supports interactive trees -- to enable a rich, editable trees in
     Shiny.

--- a/R/shiny-tree.R
+++ b/R/shiny-tree.R
@@ -64,7 +64,7 @@ shinyTree <- function(outputId, checkbox=FALSE, search=FALSE,
     animation = 'false'
   }
   if(!is.null(types)){
-    types <- paste0(outputId,"_sttypes = ",types)
+    types <- paste0(gsub("-", "_", outputId, fixed = TRUE), "_sttypes = ", types)
   }
   shiny::tagList(
     shiny::singleton(shiny::tags$head(

--- a/README.md
+++ b/README.md
@@ -179,6 +179,13 @@ runApp(system.file("examples/17-contextmenu", package="shinyTree"))
 
 Demonstrates how to enable the contextmenu.
 
+#### 18-modules
+```
+library(shiny)
+runApp(system.file("examples/18-modules", package="shinyTree"))
+```
+
+Demonstrates how to use a tree in a module.
 Known Bugs
 ----------
 

--- a/inst/examples/18-modules/app.R
+++ b/inst/examples/18-modules/app.R
@@ -1,0 +1,57 @@
+library(shiny)
+library(shinyTree)
+
+
+elem <- structure("", sttype = "elem")
+my_tree <- list(root1 = structure(list(elem1 = elem, elem2 = elem, elem3 = elem), 
+                                  sttype = "root"),
+                root2 = structure(list(elem1 = elem, elem2 = elem, elem3 = elem), 
+                                  sttype = "root"),
+                root3 = structure(list(elem1 = elem, elem2 = elem, elem3 = elem),
+                                  sttype = "root"))
+
+get_part_tree <- function(scope) {
+  part_tree <- my_tree[-sample(3, 1)]
+  names(part_tree) <- paste(scope, names(part_tree), sep = "_")
+  part_tree
+}
+
+tree_module_ui <- function(id) {
+  ns <- NS(id)
+  tagList(
+    actionButton(ns("go"), "Go!"),
+    h4("Tree with Types"),
+    shinyTree(ns("tree_with_type"),
+              types = "{'root': {'icon': 'fa fa-archive'}, 'elem':{'icon': 'fa fa-file'}}"),
+    h4("Tree without Types"),
+    shinyTree(ns("tree_without_type"))
+  )
+}
+
+tree_module <- function(input, output, session) {
+  output$tree_without_type <- renderTree({
+    input$go
+    get_part_tree("Module w/o Type")
+  })
+  
+  output$tree_with_type <- renderTree({
+    input$go
+    get_part_tree("Module w/ Type")
+  })
+}
+
+ui <- fluidPage(
+  h3("Module 1"),
+  tree_module_ui("tree_module1"),
+  h3("Module 2"),
+  tree_module_ui("tree_module2")
+)
+
+server <- function(input, output, session) {
+  callModule(tree_module,
+             "tree_module1")
+  callModule(tree_module,
+             "tree_module2")
+}
+
+shinyApp(ui, server)

--- a/inst/www/shinyTree.js
+++ b/inst/www/shinyTree.js
@@ -39,8 +39,8 @@ var shinyTree = function(){
         plugins.push('contextmenu');
       }
       var sttypes = null;
-      if(typeof window[el.id + "_sttypes"] !== 'undefined'){
-        sttypes = window[el.id + "_sttypes"];
+      if(typeof window[el.id.replace("-", "_") + "_sttypes"] !== 'undefined'){
+        sttypes = window[el.id.replace("-", "_") + "_sttypes"];
       }
       var tree = $(el).jstree({
         'core': {


### PR DESCRIPTION
This  closes #81. 

Dashes were replaced by underscores in the HTML generating function and in the respective JS file, which refers to this. An example was added based on the reprex in #81.