### PR TITLE
Update option example and test cases

### DIFF
--- a/R/data.tree-conversion.R
+++ b/R/data.tree-conversion.R
@@ -50,7 +50,7 @@ treeToJSON <- function(tree,
     stop(msg, domain = NA)
   }
   nodesToKeep <- list(default = c("id", "text", "icon", "state",
-                                  "li_attr", "a_attr"),
+                                  "li_attr", "a_attr", "type"),
                       all     = NULL)
   topLevelSlots <- tryCatch(nodesToKeep[[match.arg(topLevelSlots)]],
                             error = function(e) topLevelSlots)

--- a/R/data.tree-conversion.R
+++ b/R/data.tree-conversion.R
@@ -132,7 +132,7 @@ treeToJSON <- function(tree,
       warning(paste("old ids are invalid (duplicated values or NA),",
                     "creating new ids"),
               domain = NA)
-      new_ids <- seq_along
+      new_ids <- seq_along(nodes)
     } else {
       new_ids <- old_ids
     }

--- a/R/data.tree-conversion.R
+++ b/R/data.tree-conversion.R
@@ -75,7 +75,7 @@ treeToJSON <- function(tree,
     }
     fields$icon <- fixIconName(fields$icon)
     if (!is.null(fields$state)) {
-      valid_states <- c("opened", "disabled", "selected")
+      valid_states <- c("opened", "disabled", "selected", "loaded")
       states_template <- stats::setNames(rep(list(FALSE), length(valid_states)),
                                          valid_states)
       NOK <- !names(fields$state) %in% valid_states

--- a/inst/examples/21-options/app_setState_refresh.R
+++ b/inst/examples/21-options/app_setState_refresh.R
@@ -3,16 +3,18 @@ library(shinyTree)
 
 ## OPTIONS #####################
 options(shinyTree.setState = FALSE)
-# options(shinyTree.refresh = TRUE)
+options(shinyTree.refresh  = FALSE)
 
 ## TREE DATA ###################
-tree = list(a=list(a1=1,a2=2) , b="b") 
-tree = lapply(tree, function(x) structure(x, stopened = T))
+tree <- list(a = list(a1 = 1, a2 = 2), b = "b") 
+tree <- lapply(tree, function(x) structure(x, stopened = TRUE))
 
 ## UI ######################
 ui <- fluidPage(
   sidebarLayout(
     sidebarPanel(
+      checkboxInput("refresh", "options(shinyTree.refresh)"),
+      checkboxInput("set_state", "options(shinyTree.setState)"),
       actionButton('reset', 'Reset nodes'),
       hr(),
       helpText(HTML(
@@ -25,7 +27,7 @@ ui <- fluidPage(
         ))
     ),
     mainPanel(
-      shinyTree("tree", ),
+      uiOutput("tree_placeholder"),
       hr(),
       h4("Selected nodes:"),
       verbatimTextOutput("idSelected")
@@ -35,18 +37,25 @@ ui <- fluidPage(
 
 ## Server ######################
 server <- function(input, output, session) {
-  output$tree = renderTree({
-    attr(tree[[1]][[2]], "stselected") <- TRUE
-    tree
-  })
-  
+
+
   output$idSelected <- renderPrint({
-    str(get_selected(input$tree, format = "classid"))
+    str(get_selected(req(input$tree), format = "classid"))
   })
   
   # An observer is used to trigger a tree update when reset is clicked.
   observeEvent(input$reset, {
-    updateTree(session,"tree", data = tree)
+    updateTree(session, "tree", data = tree)
+  })
+  
+  observe({
+    options(shinyTree.setState = input$set_state)
+    options(shinyTree.refresh = input$refresh)
+    output$tree_placeholder <- renderUI(shinyTree("tree"))
+    output$tree <- renderTree({
+      attr(tree[[1]][[2]], "stselected") <- TRUE
+      tree
+    })
   })
 }
 

--- a/man/shinyTree.Rd
+++ b/man/shinyTree.Rd
@@ -62,7 +62,7 @@ fill it via \code{\link{renderTree}} you can access its content via \code{input$
 (for example after the user rearranged some nodes). By default, \code{input$tree} will
 return a list similiar to the one you use to fill the tree. This behaviour is controlled
 by \code{getOption("shinyTree.defaultParser")}. It defaults to \code{"list"}, but can be set 
-to \code{"tree"}, in which case a \link[data.tree]{data.tree} is returned.
+to \code{"tree"}, in which case a \code{\link[data.tree]{data.tree}} is returned.
 }
 \seealso{
 \code{\link{renderTree}}

--- a/man/treeToJSON.Rd
+++ b/man/treeToJSON.Rd
@@ -5,7 +5,7 @@
 \title{Converts a data.tree to a JSON format}
 \usage{
 treeToJSON(tree, keepRoot = FALSE, topLevelSlots = c("default", "all"),
-  pretty = FALSE)
+  createNewId = TRUE, pretty = FALSE)
 }
 \arguments{
 \item{tree}{the data.tree which should be parses}
@@ -21,6 +21,10 @@ are stored in an own slot called \sQuote{data}. If \code{all} *all* nodes are
 stored on the top level. Alternatively, it can be an explicit vector of
 slot names which should be kept. In the latter case it is the user's
 responsibility to ensure that jsTree slots stay on the top level.}
+
+\item{createNewId}{logical. If \code{TRUE} a new id will be generated. Any old \sQuote{id} 
+will be stored in \sQuote{id.orig} and a warning will be issued, If \code{FALSE},
+any existing id will be re-used.}
 
 \item{pretty}{logical. If \code{TRUE} the resulting JSON is prettified}
 }

--- a/tests/testthat/test_tree.R
+++ b/tests/testthat/test_tree.R
@@ -197,11 +197,11 @@ test_that("shinyTree", {
   
   ## Custom shinyTree with different themes ############
   res <- shinyTree("tree", theme = "default-dark")
-  print(unlistShinytagList(res, theme = "default-dark"))
+  # print(unlistShinytagList(res, theme = "default-dark"))
   expect_true(all(unlistShinytagList(res, theme = "default-dark")))
   
   res <- shinyTree("tree", theme = "proton")
-  print(unlistShinytagList(res, theme = "proton"))
+  # print(unlistShinytagList(res, theme = "proton"))
   expect_true(all(unlistShinytagList(res, theme = "proton")))
   
   ## ERROR: wrong theme ############

--- a/tests/testthat/test_tree_interactive.R
+++ b/tests/testthat/test_tree_interactive.R
@@ -5,10 +5,11 @@ library(shinytest)
 library(testthat)
 
 # open Shiny app and PhantomJS
-app <- ShinyDriver$new(test_path("apps/test_selec"))
+app <- try(ShinyDriver$new(test_path("apps/test_selec")), 
+           silent = TRUE)
 test_that("interactive_tests", {
   skip_on_cran()
-  
+  skip_if(inherits(app, "try-error"), "ShinyDriver could not be started. Are you sitting behind a proxy?")
   x <- app$getAllValues()
   
   expect_true(x$input$action == 0)
@@ -27,14 +28,16 @@ test_that("interactive_tests", {
   expect_equal(x$output$sel_slices, "[[1]]\n[[1]]$root2\n[[1]]$root2$SubListA\n[[1]]$root2$SubListA$leaf1\n[1] 0\n\n\n\n")
   
 })
-app$stop()
-
+if (!inherits(app, "try-error")) {
+  app$stop()
+}
 
 # open Shiny app and PhantomJS
-app <- ShinyDriver$new(test_path("apps/test_async"))
+app <- try(ShinyDriver$new(test_path("apps/test_async")),
+           silent = TRUE)
 test_that("interactive_tests_async", {
   skip_on_cran()
-  
+  skip_if(inherits(app, "try-error"), "ShinyDriver could not be started. Are you sitting behind a proxy?")
   x <- app$getAllValues()
   
   expect_true(x$input$action == 0)
@@ -52,4 +55,6 @@ test_that("interactive_tests_async", {
   expect_equal(x$output$sel_classid, "[[1]]\n[1] \"leaf1\"\nattr(,\"id\")\n[1] \"4\"\n")
   expect_equal(x$output$sel_slices, "[[1]]\n[[1]]$root2\n[[1]]$root2$SubListA\n[[1]]$root2$SubListA$leaf1\n[1] 0\n\n\n\n")
 })
-app$stop()
+if (!inherits(app, "try-error")) {
+  app$stop()
+}


### PR DESCRIPTION
In This PR, I updated the recently added example (via #89) on options to callback on `refresh` and `setState` to better illustrate the idea behind. In the previous example, the user had to open the `R` file and change the option setting by hand. 

In this PR, this is now done in the app, allowing the user to see the differences directly, without the need to interfere with the examples.

Additionally, I added some logic to conditionally skip some tests, in case the ShinyDriver could not be started (which is the case if the developer sits behind a company proxy).

Finally, the user has the choice to keep existing ids in case needed.