### PR TITLE
Fix typo in example 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Demonstrates how to render a tree asynchronously.
 
 ```
 library(shiny)
-runApp(system.file("examples/17-contextmenu", package = shinyTree"))
+runApp(system.file("examples/17-contextmenu", package = "shinyTree"))
 ```
 
 Demonstrates how to enable the contextmenu.
@@ -205,7 +205,7 @@ Demonstrates how to pass a data.tree to shinyTree.
 
 ```
 library(shiny)
-runApp(system.file("examples/20-api", package="shinyTree"))
+runApp(system.file("examples/20-api", package = "shinyTree"))
 ```
 
 An example demonstrating how to extend the operations on the tree to the rest of
@@ -219,10 +219,10 @@ runApp(system.file("examples/21-options/app_setState_refresh.R", package="shinyT
 ```
 
 Demonstrates how to fine-tune shinyTree's behaviour with options. Specifically:
-When internal jstree code calls set_state or refresh, a callback is made so that the shiny
-server is notified and observe and observeEvents for the tree are fired.
-This can be useful if the developer would like observe and observeEvents to run after
-using updateTree. (By default, updateTree does not run observe or observeEvent because it
+When internal `jstree` code calls `set_state` or `refresh`, a callback is made so that the shiny
+server is notified and `observe` and `observeEvents` for the tree are fired.
+This can be useful if the developer would like `observe` and `observeEvents` to run after
+using `updateTree`. (By default, `updateTree` does not run `observe` or `observeEvent` because it
 is assumed that the shiny application knows that the tree is being changed already.)
 
 Known Bugs


### PR DESCRIPTION
 - Example 17 was not running because of a missing `"`.
 - Added some formatting to the last paragraph to clarify functions mentioned in the text.