### PR TITLE
bugfix_shinyInputHandler

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: shinyTree
 Type: Package
 Title: jsTree Bindings for Shiny
-Version: 0.2.7
-Date: 2019-05-27
+Version: 0.2.8
+Date: 2020-09-24
 Authors@R: c(
   person(family="Trestle Technology, LLC", role="aut", email="cran@trestletechnology.net"),
   person("Jeff", "Allen", role="aut", email="cran@trestletechnology.net"),

--- a/R/init.R
+++ b/R/init.R
@@ -12,7 +12,7 @@ initResourcePaths <- function() {
 
 # Parse incoming shinyTree input from the client
 #' @importFrom methods loadMethod
-.onAttach <- function(libname, pkgname) {
+.onLoad <- function(libname, pkgname) {
   ## set the default parser to list to keep backwards compatibility
   ## can be set by the user to "tree" to receive a data.tree
   options(shinyTree.defaultParser = "list")


### PR DESCRIPTION
change .onAttach to .onLoad
related to # 99

This removes the need to call library() so functions can be imported into other packages.