### PR TITLE
Update data.tree-conversion.R

### DIFF
--- a/R/data.tree-conversion.R
+++ b/R/data.tree-conversion.R
@@ -58,7 +58,7 @@ treeToJSON <- function(tree,
                             error = function(e) topLevelSlots)
   node_to_list <- function(node, 
                            node_name = NULL) {
-    fields <- mget(node$fields, node)
+    fields <- mget(node$attributes, node)
     NOK <- sapply(fields, function(slot) !is.atomic(slot) && !is.list(slot))
     if (any(NOK)) {
       msg <- sprintf(ngettext(length(which(NOK)),


### PR DESCRIPTION
Replace node$fields with node$attributes because node$fields is deprecated in data.tree package.