### PR TITLE
Update the shinyTree input when the checkbox is changed separately from the selection

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -88,7 +88,7 @@ supplementAttr <- function(ret, json){
     if (json$state$selected != FALSE){
       attr(ret, "stselected") <- json$state$selected
     }
-    if (json$state$selected != FALSE){
+    if (json$state$checked != FALSE){
       attr(ret, "stchecked") <- json$state$checked
     }
     if (json$state$disabled != FALSE){

--- a/inst/www/shinyTree.js
+++ b/inst/www/shinyTree.js
@@ -194,6 +194,21 @@ var shinyTree = function(){
         });
       }
       
+      if (el.dataset.stCheckbox == "TRUE" && el.dataset.stTieSelection == "FALSE") {
+        $(el).on("check_node.jstree", function(e) {
+          callback();
+        });
+        $(el).on("uncheck_node.jstree", function(e) {
+          callback();
+        });
+        $(el).on("check_all.jstree", function(e) {
+          callback();
+        });
+        $(el).on("uncheck_all.jstree", function(e) {
+          callback();
+        });
+      }
+      
     },
     unsubscribe: function(el) {
       $(el).off(".jstree");


### PR DESCRIPTION
When the checkbox is just another way to select things in the tree, clicking the box will trigger the selection, which then triggers the shiny tree to update. However, if tie_selection is false, a checkbox change alone does not currently update the shinyTree input as it should. This change fixes this behavior and triggers Shiny to detect an input change in the case that checkbox is true and tie_selection is false whenever a checkbox is unchecked or checked or the check all or uncheck all actions are triggered.