### PR TITLE
Add default text value when creating a new node

### DIFF
--- a/inst/www/shinyTree.js
+++ b/inst/www/shinyTree.js
@@ -110,6 +110,9 @@ var shinyTree = function(){
           $.each(obj, function(key, val){
             if (keys.indexOf(key) >= 0) {
                 if (typeof val === 'string'){
+                  if (key === "text" && val === "") {
+                    val = "New node";
+                  }
                   clean[key] = val.trim();
                 } else {
                   clean[key] = val; 


### PR DESCRIPTION
By default the text value is an empty string, which causes the app to crash when using the `tree` parser.

I add the placeholder as the default value.

This default value will be erased once the user confirms the name of the new node, which will always happen, voluntarily or not (the name gets confirmed as soon as the focus is not on the text field anymore, e.g. if the user clicks somewhere else).

Related to issue #124 