### PR TITLE
Add placeholder text to search box

### DIFF
--- a/R/shiny-tree.R
+++ b/R/shiny-tree.R
@@ -13,7 +13,7 @@
 #' @param outputId The ID associated with this element
 #' @param checkbox If \code{TRUE}, will enable checkboxes next to each node to 
 #' make the selection of multiple nodes in the tree easier.
-"' @param searchplaceholder Add a placeholder value to the search box
+#' @param searchplaceholder Add a placeholder value to the search box
 #' @param search If \code{TRUE}, will enable search functionality in the tree by adding
 #' a search box above the produced tree. Alternatively, you can set the parameter
 #' to the ID of the text input you wish to use as the search field.

--- a/R/shiny-tree.R
+++ b/R/shiny-tree.R
@@ -13,6 +13,7 @@
 #' @param outputId The ID associated with this element
 #' @param checkbox If \code{TRUE}, will enable checkboxes next to each node to 
 #' make the selection of multiple nodes in the tree easier.
+"' @param searchplaceholder Add a placeholder value to the search box
 #' @param search If \code{TRUE}, will enable search functionality in the tree by adding
 #' a search box above the produced tree. Alternatively, you can set the parameter
 #' to the ID of the text input you wish to use as the search field.
@@ -41,7 +42,7 @@
 #' @seealso \code{\link{renderTree}}
 #' @export
 shinyTree <- function(outputId, checkbox=FALSE, search=FALSE, 
-                      searchtime = 250, dragAndDrop=FALSE, types=NULL, 
+                      searchtime = 250, searchplaceholder = "", dragAndDrop=FALSE, types=NULL, 
                       theme="default", themeIcons=TRUE, themeDots=TRUE,
                       sort=FALSE, unique=FALSE, wholerow=FALSE,
                       stripes=FALSE, multiple=TRUE, animation=200,
@@ -55,7 +56,7 @@ shinyTree <- function(outputId, checkbox=FALSE, search=FALSE,
   searchEl <- shiny::div("")
   if (search == TRUE){
     search <- paste0(outputId, "-search-input")
-    searchEl <- shiny::tags$input(id=search, class="input", type="text", value="")
+    searchEl <- shiny::tags$input(id=search, class="input", type="text", value="", placeholder = searchplaceholder)
   }
   if (is.character(search)){
     # Either the search field we just created or the given text field ID

--- a/man/shinyTree.Rd
+++ b/man/shinyTree.Rd
@@ -9,6 +9,7 @@ shinyTree(
   checkbox = FALSE,
   search = FALSE,
   searchtime = 250,
+  searchplaceholder = "",
   dragAndDrop = FALSE,
   types = NULL,
   theme = "default",
@@ -38,6 +39,8 @@ to the ID of the text input you wish to use as the search field.}
 
 \item{searchtime}{Determines the reaction time of the search algorithm.
 Default is 250ms.}
+
+\item{searchplaceholder}{Add a placeholder value to the search box}
 
 \item{dragAndDrop}{If \code{TRUE}, will allow the user to rearrange the nodes in the
 tree.}


### PR DESCRIPTION
The search box for the shinyTree is now an empty, floating input element. To make the element's function more clear, I suggest adding the option to set a placeholder.

The impact for end users should be minimal:
- It has a default value (an empty string), so it does not change anything upon installation
- It works as a named argument, so any implementation using named arguments should continue to work